### PR TITLE
Fix flaky E2E specs: increase Capybara timeout + OS-agnostic select-all

### DIFF
--- a/spec/e2e/features/ajax_form_integration_spec.rb
+++ b/spec/e2e/features/ajax_form_integration_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe 'AJAX Form Integration', type: :feature, js: true do
     end
 
     it 'validates required fields' do
-      editable.click
-      editable.send_keys([[:control, 'a'], :backspace])
+      clear_editor_content(editable)
       text_field.set('')
       submit_button.click
 
@@ -38,9 +37,7 @@ RSpec.describe 'AJAX Form Integration', type: :feature, js: true do
     it 'submits form and shows response' do
       test_content = "Test content #{Time.now.to_i}"
 
-      editable.click
-      editable.send_keys([[:control, 'a'], :backspace])
-      editable.send_keys(test_content)
+      replace_editor_content(editable, test_content)
 
       sleep 1
 

--- a/spec/e2e/features/context_spec.rb
+++ b/spec/e2e/features/context_spec.rb
@@ -20,14 +20,10 @@ RSpec.describe 'CKEditor5 Context Integration', type: :feature, js: true do
     editors = all('.ck-editor__editable', count: 2, wait: 10)
 
     # Test first editor
-    editors[0].click
-    editors[0].send_keys([[:control, 'a'], :backspace])
-    editors[0].send_keys('Modified Context Item 1')
+    replace_editor_content(editors[0], 'Modified Context Item 1')
 
     # Test second editor
-    editors[1].click
-    editors[1].send_keys([[:control, 'a'], :backspace])
-    editors[1].send_keys('Modified Context Item 2')
+    replace_editor_content(editors[1], 'Modified Context Item 2')
 
     # Verify content
     expect(editors[0].text).to eq('Modified Context Item 1')

--- a/spec/e2e/features/editor_types_spec.rb
+++ b/spec/e2e/features/editor_types_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe 'CKEditor5 Types Integration', type: :feature, js: true do
       JS
 
       # Clear editor and type text
-      editor.click
-      editor.send_keys([[:control, 'a'], :backspace])
-      editor.send_keys('Hello from keyboard!')
+      replace_editor_content(editor, 'Hello from keyboard!')
 
       # Wait for change events and verify the last one
       eventually do
@@ -68,12 +66,8 @@ RSpec.describe 'CKEditor5 Types Integration', type: :feature, js: true do
       # Test each editable
       expected_data = {}
       editors.each_with_index do |editor, index|
-        editor.click
-        editor.send_keys([[:control, 'a'], :backspace])
-
         content = "Content for #{editables[index]}"
-
-        editor.send_keys(content)
+        replace_editor_content(editor, content)
         expected_data[editables[index]] = "<p>#{content}</p>"
       end
 
@@ -178,9 +172,7 @@ RSpec.describe 'CKEditor5 Types Integration', type: :feature, js: true do
       expect(page).to have_css('.ck-editor__editable', minimum: 3, wait: 10)
 
       new_editable = find("[name='new-root']")
-      new_editable.click
-      new_editable.send_keys([[:control, 'a'], :backspace])
-      new_editable.send_keys('Content for new root')
+      replace_editor_content(new_editable, 'Content for new root')
 
       eventually do
         events = page.evaluate_script('window._newEditableEvents')

--- a/spec/e2e/features/form_integration_spec.rb
+++ b/spec/e2e/features/form_integration_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe 'Form Integration', type: :feature, js: true do
     end
 
     it 'validates required fields' do
-      editable.click
-      editable.send_keys([[:control, 'a'], :backspace])
+      clear_editor_content(editable)
 
       text_field.set('')
       submit_button.click

--- a/spec/e2e/spec_helper.rb
+++ b/spec/e2e/spec_helper.rb
@@ -40,6 +40,7 @@ end
 Capybara.server = :webrick
 Capybara.default_driver = :cuprite
 Capybara.javascript_driver = :cuprite
+Capybara.default_max_wait_time = 10
 
 RSpec.configure do |config|
   config.around :each, :js do |example|

--- a/spec/e2e/support/form_helpers.rb
+++ b/spec/e2e/support/form_helpers.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
 module FormHelpers
+  def clear_editor_content(editor)
+    editor.click
+    editor.send_keys([select_all_modifier, :backspace])
+  end
+
+  def replace_editor_content(editor, new_content)
+    clear_editor_content(editor)
+    editor.send_keys(new_content)
+  end
+
+  def select_all_modifier
+    case RbConfig::CONFIG['host_os']
+    when /darwin/i
+      [:command, 'a']
+    else
+      [:control, 'a']
+    end
+  end
+
   def setup_form_tracking(driver)
     driver.execute_script <<~JS
       window.lastSubmittedForm = null;


### PR DESCRIPTION
Two issues causing random E2E failures:

1. Capybara's default 2 sec. timeout sometimes was too short for CKEditor initialization.
2. `[send_keys([[:control, 'a'], :backspace])]` doesn't work on macOS (`Cmd + A` needed instead).

Changes:

1. Set `Capybara.default_max_wait_time = 10`
2. Added helper methods to detect OS and use the correct modifier key